### PR TITLE
fixing build script

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
 
 if [ ! -d "node_modules/uswds/dist" ]; then
-  npm run uswds-install && npm run uswds-build
+  npm run jekyll-install && npm run uswds-build
 fi


### PR DESCRIPTION
This fixes an issue in the build script there it was looking for `install-uswds` when it should probably have been `install-jekyll`