### PR TITLE
Serve from localhost

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "federalist": "npm install && npm run uswds-copy-assets && npm run uswds-build-sass",
     "jekyll-install": "gem install bundler && bundle install",
-    "serve": "bundle exec jekyll serve --livereload",
+    "serve": "bundle exec jekyll serve --livereload --host=localhost",
     "start": "npm install && npm update uswds && npm run jekyll-install && npm run uswds-copy-assets && npm run uswds-copy-theme && npm run uswds-build-sass",
     "uswds-build-sass": "gulp build-sass",
     "uswds-build-app": "gulp build-app",


### PR DESCRIPTION
It serves from `http://127.0.0.1:4000/` and should serve from `http://localhost:4000/`per the README. The current way causes CORS issues when setting a URL to assets bc when you hit http://127.0.0.1:4000/, it's still trying to load the assets from localhost, but that's technically a different origin (http://127.0.0.1:4000/).

