### PR TITLE
Watch for SASS changes

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -1,5 +1,10 @@
 module.exports = function (eleventyConfig) {
   eleventyConfig.addPassthroughCopy("assets");
+  eleventyConfig.addWatchTarget("./_sass");
+
+  // Wait for SASS to compile, set to 2s because our compile task is 1.7s
+  eleventyConfig.setWatchThrottleWaitTime(2000);
+
   let pathPrefix = "/";
 
   if (process.env.BASEURL) {


### PR DESCRIPTION
Closes #86.

- Watch SASS directory in config
- Set throttle to wait for USWDS to compile


# How to test
- Run `npm start`
- Change a SASS file
- Site should reload **after** SASS compiles