### PR TITLE
Remove project assets from gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,7 @@
 .DS_Store
 _site
 .jekyll-cache
-assets
+_site/assets
 src/assets/img
 src/assets/css
 src/assets/fonts


### PR DESCRIPTION
Removes project assets from gitignore. Closes #94.

## How to test

1. Create a folder with a file in `./src/assets/project`
2. Files **should** appear in git