### PR TITLE
USWDS-Sandbox - Test: USWDS custom breakpoints feature

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,7 @@
       "name": "uswds-sandbox",
       "license": "CC0-1.0",
       "dependencies": {
-        "@uswds/uswds": "3.8.1"
+        "@uswds/uswds": "github:uswds/uswds#theme-utility-breakpoints-custom"
       },
       "devDependencies": {
         "@11ty/eleventy": "^2.0.1",
@@ -474,8 +474,8 @@
     },
     "node_modules/@uswds/uswds": {
       "version": "3.8.1",
-      "resolved": "https://registry.npmjs.org/@uswds/uswds/-/uswds-3.8.1.tgz",
-      "integrity": "sha512-bKG/B9mJF1v0yoqth48wQDzST5Xyu3OxxpePIPDyhKWS84oDrCehnu3Z88JhSjdIAJMl8dtjtH8YvdO9kZUpAg==",
+      "resolved": "git+ssh://git@github.com/uswds/uswds.git#5abc90cff1a6c0a08413372a403ee278997a03ba",
+      "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
         "classlist-polyfill": "1.2.0",
         "object-assign": "4.1.1",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "test": "snyk test"
   },
   "dependencies": {
-    "@uswds/uswds": "3.8.1"
+    "@uswds/uswds": "github:uswds/uswds#theme-utility-breakpoints-custom"
   },
   "devDependencies": {
     "@11ty/eleventy": "^2.0.1",

--- a/src/_styles/_uswds-theme.scss
+++ b/src/_styles/_uswds-theme.scss
@@ -1,6 +1,8 @@
 @use "uswds-core" with (
   $theme-show-compile-warnings: false,
   $theme-show-notifications: false,
-  // $theme-font-type-sans: "public-sans",
-  // $theme-body-background-color: "ink",
+  $theme-utility-breakpoints-custom: (
+    // 3840px
+    "custom-widescreen-lg": 240rem,
+  )
 );


### PR DESCRIPTION
Testing uswds/uswds#5985.

### Testing

#### Using REM

This builds fine without issues.

**Input**
```scss
@use "uswds-core" with (
  $theme-show-compile-warnings: false,
  $theme-show-notifications: false,
  $theme-utility-breakpoints-custom: (
    // 3840px
    "custom-widescreen-lg": 240rem,
  )
);
```

**Output**
```css
@media all and (min-width: 240em) {
  .custom-widescreen-lg\:border-1px {
    border: 1px solid;
  }

  .custom-widescreen-lg\:hover\:border-1px:hover {
    border: 1px solid;
  }

  // etc…
}
```

<details><summary>Using pixels (error)</summary>
<p></p>

**Input**
```scss
@use "uswds-core" with (
  $theme-show-compile-warnings: false,
  $theme-show-notifications: false,
  $theme-utility-breakpoints-custom: (
    // Doesn't work with unitless `3840` either.
    "custom-widescreen-lg": 3840px,
  )
);
```

**Output**

```sh
Compiling with USWDS 3.8.1
node_modules/@uswds/uswds/packages/uswds-core/src/styles/mixins/helpers/at-media.scss
Error: 3840px*em/rem isn't a valid CSS value.
   ╷
19 │     @media all and (min-width: #{$bp}) {
   │                                  ^^^
   ╵
  node_modules/@uswds/uswds/packages/uswds-core/src/styles/mixins/helpers/at-media.scss 19:34  at-media()
  uswds-core/src/styles/mixins/_utility-builder.scss 363:7                                     render-utilities-in()
  uswds-utilities/src/_index.scss 11:1                                                         @forward
  _index.scss 55:1                                                                             @forward
  src/_styles/styles.scss 2:1    
```

</details> 


<details><summary>Using EM (error)</summary>
<p></p>

```sh
Compiling with USWDS 3.8.1
node_modules/@uswds/uswds/packages/uswds-core/src/styles/mixins/helpers/at-media.scss
Error: 240em*em/rem isn't a valid CSS value.
   ╷
19 │     @media all and (min-width: #{$bp}) {
   │                                  ^^^
```
</details> 




### CSS compilation size

| File | Before | After |
| :----- | :----- | :---- |
| styles.min.css | 524KB | 578KB | 
| styles.css | 755KB | 826KB |