### PR TITLE
USWDS-Sandbox - README: Add instructions for installing a USWDS branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,31 +6,29 @@ An eleventy site for rapid web prototyping and testing new work with USWDS. This
 
 - Node v20 (LTS)
 
-## Running code locally
+## Running locally
 
-After cloning the template repo, install USWDS, eleventy, and any necessary dependencies using:
+To run `uswds-sandbox` locally:
 
-```
-npm install
-```
-
-Then, copy USWDS images, fonts, and JavaScript to a project directory.
-
-```
-npm run init
-```
-
-Finally, serve the site locally and watch for changes:
-
-```
-npm start
-```
-
-If all goes well, visit the site at http://localhost:8080.
+1. Clone the `uswds-sandbox` repo.
+2. Run `npm install` to install USWDS, eleventy, and other necessary dependencies.
+3. Run `npm run init` to copy USWDS images, fonts, and JavaScript to a project directory.
+4. Run `npm start` to serve the site locally and watch for changes.
+5. If all goes well, visit the site at http://localhost:8080.
 
 USWDS assets will be in `assets/fonts` and `assets/img`.
 
 SASS files will be in the `/_styles` directory. Running `npm start` will also watch these files and recompile when there are changes.
+
+## Running locally with a development version of USWDS
+
+If you have made changes to the `uswds` project and want to test it with `uswds-sandbox`:
+
+1. Push your changes to `uswds` to a branch on GitHub.
+2. In your `uswds-sandbox` working copy, run `npm install "https://github.com/YOUR_USERNAME/uswds/tree/YOUR_BRANCH" --save` where the URL refers to your `uswds` branch.
+3. Run `npm install` to install dependencies including your new version of `uswds`.
+4. Run `npm run init`.
+5. Run `npm start` and open http://localhost:8080.
 
 ## Templates
 

--- a/README.md
+++ b/README.md
@@ -6,21 +6,33 @@ An eleventy site for rapid web prototyping and testing new work with USWDS. This
 
 - Node v20 (LTS)
 
-## Running locally
+## Running code locally
 
-To run `uswds-sandbox` locally:
+After cloning the template repo, install USWDS, eleventy, and any necessary dependencies using:
 
-1. Clone the `uswds-sandbox` repo.
-2. Run `npm install` to install USWDS, eleventy, and other necessary dependencies.
-3. Run `npm run init` to copy USWDS images, fonts, and JavaScript to a project directory.
-4. Run `npm start` to serve the site locally and watch for changes.
-5. If all goes well, visit the site at http://localhost:8080.
+```
+npm install
+```
+
+Then, copy USWDS images, fonts, and JavaScript to a project directory.
+
+```
+npm run init
+```
+
+Finally, serve the site locally and watch for changes:
+
+```
+npm start
+```
+
+If all goes well, visit the site at http://localhost:8080.
 
 USWDS assets will be in `assets/fonts` and `assets/img`.
 
 SASS files will be in the `/_styles` directory. Running `npm start` will also watch these files and recompile when there are changes.
 
-## Running locally with a development version of USWDS
+## Installing USWDS from a branch
 
 If you have made changes to the `uswds` project and want to test it with `uswds-sandbox`:
 


### PR DESCRIPTION
Builds from @jeffpw-goog contributions, thanks Jeff!

For simplicity, I've kept the original instructions. I've only included Jeff's instructions with a minor edit to the header.

This PR adds instructions on how to install USWDS from a GitHub branch.