### PR TITLE
USWDS-Sandbox - POAM: February '25

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@11ty/eleventy": "^3.0.0",
         "@uswds/compile": "^1.2.1",
         "concurrently": "^9.1.2",
-        "snyk": "^1.1294.3"
+        "snyk": "^1.1295.3"
       }
     },
     "node_modules/@11ty/dependency-tree": {
@@ -5223,9 +5223,9 @@
       }
     },
     "node_modules/snyk": {
-      "version": "1.1294.3",
-      "resolved": "https://registry.npmjs.org/snyk/-/snyk-1.1294.3.tgz",
-      "integrity": "sha512-ZF+F2bv293HmpFxZCV0x8hT3rQGOl6rPDoJq/TqBT1i5/nZypfn8v4A1Q4m6zUSUs1g6WJsS8QR5wTlR/eSvMQ==",
+      "version": "1.1295.3",
+      "resolved": "https://registry.npmjs.org/snyk/-/snyk-1.1295.3.tgz",
+      "integrity": "sha512-PFPetFXVMx5kt49WraLbr1Lw36jikktxQeOjaK3y/0Bjgm1e1rRjTsKYI83lINhkxUuSRBf9MCm8QUcOEYZiaw==",
       "dev": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",

--- a/package.json
+++ b/package.json
@@ -27,6 +27,6 @@
     "@11ty/eleventy": "^3.0.0",
     "@uswds/compile": "^1.2.1",
     "concurrently": "^9.1.2",
-    "snyk": "^1.1294.3"
+    "snyk": "^1.1295.3"
   }
 }


### PR DESCRIPTION
# Summary

Dependency updates for February 2025

## Breaking change

This is not a breaking change.

## Related issue

[USWDS-Team - POAM: February '25](https://github.com/uswds/uswds-team/issues/477)

## Preview link

[Preview link →](https://federalist-d5e7c07c-6ffa-4b8e-935f-49a7df24a505.sites.pages.cloud.gov/preview/uswds/uswds-sandbox/cm-poam-feb-25/)

## Dependency updates

```jsx
found 0 vulnerabilities
```

| Dependency Name | Old Version | New Version |
| --- | --- | --- |
| snyk | ^1.1294.3 | ^1.1295.3 |

## Testing and review

1. Confirm there are no installation errors
2. Confirm there are no build errors
3. Confirm there are no test errors
